### PR TITLE
Add Watr's spec

### DIFF
--- a/packages/apps-config/src/api/spec/watr.ts
+++ b/packages/apps-config/src/api/spec/watr.ts
@@ -1,0 +1,22 @@
+// Copyright 2017-2023 @polkadot/apps-config authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { OverrideBundleDefinition } from '@polkadot/types/types';
+
+// structs need to be in order
+/* eslint-disable sort-keys */
+
+const definitions: OverrideBundleDefinition = {
+  types: [
+    {
+      // on all versions
+      minmax: [0, undefined],
+      types: {
+        Address: 'AccountId',
+        LookupSource: 'AccountId'
+      }
+    }
+  ]
+};
+
+export default definitions;


### PR DESCRIPTION
After successful Watr's mainnet launch we include the corresponding specs.